### PR TITLE
Fix syntax error from new course 6 definitions.

### DIFF
--- a/js/majors.js
+++ b/js/majors.js
@@ -531,7 +531,7 @@ window.majors = {
         skip: 1
       },
       [1, [2, [1, "6.01", "6.S08"],
-              {id: "Programming add-on (subject number pending)"}],
+              {id: "Programming add-on (subject number pending)", skip: 1}],
           [2, "6.001", [1, "6.01", "6.02", "6.03", "6.S08"]]
       ],
       [1, "6.UAT", "6.UAR"],
@@ -747,7 +747,7 @@ window.majors = {
         skip: 1
       },
       [1, [2, [1, "6.01", "6.S08"],
-              {id: "Programming add-on (subject number pending)"}],
+              {id: "Programming add-on (subject number pending)", skip: 1}],
           [2, "6.001", [1, "6.01", "6.02", "6.03", "6.S08"]]
       ],
       [1, "6.UAT", "6.UAR"],
@@ -971,7 +971,7 @@ window.majors = {
         skip: 1
       },
       [1, [2, [1, "6.01", "6.S08"],
-              {id: "Programming add-on (subject number pending)"}],
+              {id: "Programming add-on (subject number pending)", skip: 1}],
           [2, "6.001", [1, "6.01", "6.02", "6.03", "6.S08"]]
       ],
       [1, "6.UAT", "6.UAR"],


### PR DESCRIPTION
"Uncaught Error: Syntax error, unrecognized expression: (SUBJECT NUMBER PENDING)"
This was causing a failure to populate checkboxes after the first branch of requirements in the new 6-1, 6-2, and 6-3 major paths.

Fix tested and verified locally.
